### PR TITLE
Fix unlinkPlayer

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/Discord.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/Discord.java
@@ -343,11 +343,11 @@ public class Discord extends Thread {
                 for (PlayerLink p : PlayerLinkController.getAllLinks()) {
                     try {
                         if(getMemberById(Long.valueOf(p.discordID)) == null) {
-                            PlayerLinkController.unlinkPlayer(p.discordID);
+                            PlayerLinkController.unlinkPlayer(p.discordID, false);
                             unlinked++;
                         }
                     } catch (ErrorResponseException e) {
-                        PlayerLinkController.unlinkPlayer(p.discordID);
+                        PlayerLinkController.unlinkPlayer(p.discordID, false);
                         unlinked++;
                     }
                 }

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/DiscordEventListener.java
@@ -99,7 +99,7 @@ public class DiscordEventListener implements EventListener {
         }
         if (event instanceof GuildMemberRemoveEvent) {
             if (Configuration.instance().linking.unlinkOnLeave && PlayerLinkController.isDiscordLinked(((GuildMemberRemoveEvent) event).getUser().getId())) {
-                PlayerLinkController.unlinkPlayer(((GuildMemberRemoveEvent) event).getUser().getId());
+                PlayerLinkController.unlinkPlayer(((GuildMemberRemoveEvent) event).getUser().getId(), false);
             }
         }
         if (event instanceof final MessageReceivedEvent ev) {

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/PlayerLinkController.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/common/storage/PlayerLinkController.java
@@ -435,6 +435,18 @@ public class PlayerLinkController {
      */
     @SuppressWarnings({"UnusedReturnValue", "ConstantConditions"})
     public static boolean unlinkPlayer(String discordID) {
+        return unlinkPlayer(discordID, true);
+    }
+
+    /**
+     * Unlinks a player and discord id
+     *
+     * @param discordID The discord ID to unlink
+     * @param inGuild Is user in guild?
+     * @return true, if unlinking was successful
+     */
+    @SuppressWarnings({"UnusedReturnValue", "ConstantConditions"})
+    public static boolean unlinkPlayer(String discordID, boolean inGuild) {
         if (!discord_instance.srv.isOnlineMode()) return false;
         if (!isDiscordLinked(discordID)) return false;
         try {
@@ -447,15 +459,15 @@ public class PlayerLinkController {
                         gson.toJson(json, writer);
                     }
                     discord_instance.callEventC((a) -> a.onPlayerUnlink(UUID.fromString(o.mcPlayerUUID), discordID));
-                    try {
-
-                        final Guild guild = discord_instance.getChannel().getGuild();
-                        final Member member = discord_instance.getMemberById(Long.valueOf(discordID));
-                        final Role linkedRole = guild.getRoleById(Configuration.instance().linking.linkedRoleID);
-                        if (member.getRoles().contains(linkedRole))
-                            guild.removeRoleFromMember(member, linkedRole).queue();
-
-                    } catch (ErrorResponseException ignored) {
+                    if(inGuild) {
+                        try {
+                            final Guild guild = discord_instance.getChannel().getGuild();
+                            final Member member = discord_instance.getMemberById(Long.valueOf(discordID));
+                            final Role linkedRole = guild.getRoleById(Configuration.instance().linking.linkedRoleID);
+                            if (member.getRoles().contains(linkedRole))
+                                guild.removeRoleFromMember(member, linkedRole).queue();
+                        } catch (ErrorResponseException ignored) {
+                        }
                     }
                     return true;
                 }


### PR DESCRIPTION
By default it would attempt to remove a role from a player that had already left the discord server, created overload to preserve original functionality.